### PR TITLE
Rethrow original error with attached extensions

### DIFF
--- a/src/stitching/defaultMergedResolver.ts
+++ b/src/stitching/defaultMergedResolver.ts
@@ -1,5 +1,5 @@
 import { GraphQLFieldResolver, responsePathAsArray } from 'graphql';
-import { locatedError } from 'graphql/error';
+import { GraphQLError } from 'graphql/error';
 import { getErrorsFromParent, annotateWithChildrenErrors } from './errors';
 import { getResponseKeyFromInfo } from './getResponseKeyFromInfo';
 
@@ -15,7 +15,15 @@ const defaultMergedResolver: GraphQLFieldResolver<any, any> = (parent, args, con
   const errorResult = getErrorsFromParent(parent, responseKey);
 
   if (errorResult.kind === 'OWN') {
-    throw locatedError(new Error(errorResult.error.message), info.fieldNodes, responsePathAsArray(info.path));
+    const originalError = errorResult.error;
+    throw new GraphQLError(
+      originalError.message,
+      info.fieldNodes,
+      originalError.source,
+      originalError.positions,
+      responsePathAsArray(info.path),
+      originalError,
+    );
   }
 
   let result = parent[responseKey];


### PR DESCRIPTION
This fixes our stacktraces, and a regression with our ability to set the `code` field
in the graphql error extensions. It currently only reports `INTERNAL_SERVER_ERROR`, which
is likely causing problems elsewhere.

This regression has been fixed AFAICT in graphql-tools#master, but occurs due to a series
of bugs in the `transformSchema` operation.

By not using `locatedError` and instead constructing a GraphQLError here, we can preserve
the original extensions and stacktraces, where they were previously being reset.